### PR TITLE
Generic Multicast 2 specification.

### DIFF
--- a/Commons/Commons.tla
+++ b/Commons/Commons.tla
@@ -119,6 +119,9 @@ CreatePossibleMessages(S) ==
 MessagesToTuple(F) ==
     [x \in DOMAIN F |-> <<F[x], 0, 0>>]
 
+MessagesToTupleSet(F) ==
+    [x \in DOMAIN F |-> {<<F[x], 0, 0>>}]
+
 --------------------------------------------------------
 
 AppendEnumerating(base, E) ==

--- a/GenericBroadcast/GenericBroadcast.tla
+++ b/GenericBroadcast/GenericBroadcast.tla
@@ -1,0 +1,63 @@
+----------------------- MODULE GenericBroadcast -----------------------
+
+-----------------------------------------------------------------------
+
+LOCAL INSTANCE Naturals
+LOCAL INSTANCE Sequences
+LOCAL INSTANCE FiniteSets
+
+\* Number of groups.
+CONSTANT NGROUPS
+
+\* Number of processes.
+CONSTANT NPROCESSES
+
+\* The sequences of initial messages.
+CONSTANT INITIAL_MESSAGES
+
+\* The conflict relation to identify commuting messages.
+CONSTANT CONFLICTR(_, _)
+
+-----------------------------------------------------------------------
+
+VARIABLE
+    GenericBroadcastBuffer
+
+-----------------------------------------------------------------------
+
+LOCAL ReplaceAt(s, i, e) ==
+    [s EXCEPT ![i] = e]
+
+LOCAL Consume(S, m) ==
+    IF Cardinality(Head(S)) > 1 THEN ReplaceAt(S, 1, Head(S) \ {m})
+    ELSE SubSeq(S, 2, Len(S))
+
+LOCAL Insert(S, m) ==
+    IF Len(S) = 0 \/ Len(SelectSeq(S, LAMBDA V: \E n \in V: CONFLICTR(m[1], n[1]))) /= 0
+        THEN Append(S, {m})
+    ELSE ReplaceAt(S, Len(S), S[Len(S)] \cup {m})
+-----------------------------------------------------------------------
+
+GBroadcast(g, m) ==
+    /\ GenericBroadcastBuffer' = [
+        GenericBroadcastBuffer EXCEPT ![g] = [
+            i \in 1 .. Len(GenericBroadcastBuffer[g]) |->
+                Insert(GenericBroadcastBuffer[g][i], m)]]
+
+GBDeliver(g, p, Fn(_)) ==
+    /\ Len(GenericBroadcastBuffer[g][p]) > 0
+    /\ Cardinality(Head(GenericBroadcastBuffer[g][p])) > 0
+    /\ LET
+        m == CHOOSE v \in Head(GenericBroadcastBuffer[g][p]): TRUE
+       IN
+        /\ Fn(m)
+        /\ GenericBroadcastBuffer' = [
+            GenericBroadcastBuffer EXCEPT ![g][p] =
+                Consume(GenericBroadcastBuffer[g][p], m)]
+
+-----------------------------------------------------------------------
+
+Init ==
+    /\ GenericBroadcastBuffer = [g \in 1 .. NGROUPS |-> [p \in 1 .. NPROCESSES |-> INITIAL_MESSAGES[g]]]
+
+=======================================================================

--- a/GenericMulticast2/Agreement/Agreement-AlwaysConflict.cfg
+++ b/GenericMulticast2/Agreement/Agreement-AlwaysConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 2
+    NGROUPS = 2
+    CONFLICTR <- AlwaysConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Agreement

--- a/GenericMulticast2/Agreement/Agreement-IdConflict.cfg
+++ b/GenericMulticast2/Agreement/Agreement-IdConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 2
+    NGROUPS = 2
+    CONFLICTR <- IdConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Agreement

--- a/GenericMulticast2/Agreement/Agreement-NeverConflict.cfg
+++ b/GenericMulticast2/Agreement/Agreement-NeverConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 2
+    NGROUPS = 2
+    CONFLICTR <- NeverConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Agreement

--- a/GenericMulticast2/Agreement/Agreement.tla
+++ b/GenericMulticast2/Agreement/Agreement.tla
@@ -1,0 +1,63 @@
+-------------------- MODULE Agreement --------------------
+EXTENDS Naturals, FiniteSets, Commons
+
+CONSTANT NPROCESSES
+CONSTANT NGROUPS
+CONSTANT NMESSAGES
+CONSTANT CONFLICTR(_, _)
+
+----------------------------------------------------------
+
+LOCAL Processes == {i : i \in 1 .. NPROCESSES}
+LOCAL Groups == 1 .. NGROUPS
+LOCAL ProcessesInGroup == [g \in Groups |-> Processes]
+
+LOCAL AllMessages == CreateMessages(NMESSAGES, Groups, Processes)
+LOCAL MessagesCombinations == CreatePossibleMessages(AllMessages)
+
+----------------------------------------------------------
+
+VARIABLES
+    K,
+    PreviousMsgs,
+    Delivered,
+    Votes,
+    MemoryBuffer,
+    QuasiReliableChannel,
+    GenericBroadcastBuffer
+Algorithm == INSTANCE GenericMulticast2 WITH
+    INITIAL_MESSAGES <- [g \in Groups |-> MessagesToTupleSet(MessagesCombinations[(g % NMESSAGES) + 1])]
+
+vars == <<
+    K,
+    PreviousMsgs,
+    Delivered,
+    Votes,
+    MemoryBuffer,
+    QuasiReliableChannel,
+    GenericBroadcastBuffer
+>>
+----------------------------------------------------------
+
+Spec == Algorithm!SpecFair
+
+----------------------------------------------------------
+(***************************************************************************)
+(*                                                                         *)
+(*     If a correct process GM-Deliver a message `m`, then all correct     *)
+(* processes in `m.d` eventually GM-Deliver `m`.                           *)
+(*                                                                         *)
+(*     We verify that all messages on the messages that will be send, then *)
+(* we verify that exists a process and it did deliverd the message so we   *)
+(* verify that eventually all processes in `m.d` also delivers `m`.        *)
+(*                                                                         *)
+(***************************************************************************)
+Agreement ==
+    \A m \in AllMessages:
+        \A g_i \in Groups:
+            \E p_i \in ProcessesInGroup[g_i]:
+                Algorithm!WasDelivered(g_i, p_i, m)
+                    ~> \A g_j \in m.d :
+                        \E p_j \in ProcessesInGroup[g_j]:
+                            p_j \in Processes /\ Algorithm!WasDelivered(g_j, p_j, m)
+==========================================================

--- a/GenericMulticast2/Collision/Collision-AlwaysConflict.cfg
+++ b/GenericMulticast2/Collision/Collision-AlwaysConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 4
+    NGROUPS = 2
+    CONFLICTR <- AlwaysConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Collision

--- a/GenericMulticast2/Collision/Collision-IdConflict.cfg
+++ b/GenericMulticast2/Collision/Collision-IdConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 4
+    NGROUPS = 2
+    CONFLICTR <- IdConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Collision

--- a/GenericMulticast2/Collision/Collision-NeverConflict.cfg
+++ b/GenericMulticast2/Collision/Collision-NeverConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 4
+    NGROUPS = 2
+    CONFLICTR <- NeverConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Collision

--- a/GenericMulticast2/Collision/Collision.tla
+++ b/GenericMulticast2/Collision/Collision.tla
@@ -1,0 +1,58 @@
+------------------ MODULE Collision ----------------------
+EXTENDS Naturals, FiniteSets, Commons
+
+CONSTANT NGROUPS
+CONSTANT NPROCESSES
+CONSTANT NMESSAGES
+CONSTANT CONFLICTR(_, _)
+
+----------------------------------------------------------
+
+LOCAL Processes == 1 .. NPROCESSES
+LOCAL Groups == 1 .. NGROUPS
+LOCAL ProcessesInGroup == [g \in Groups |-> Processes]
+
+LOCAL AllMessages == CreateMessages(NMESSAGES, Groups, Processes)
+LOCAL MessagesCombinations == CreatePossibleMessages(AllMessages)
+
+----------------------------------------------------------
+
+VARIABLES
+    K,
+    PreviousMsgs,
+    Delivered,
+    Votes,
+    MemoryBuffer,
+    QuasiReliableChannel,
+    GenericBroadcastBuffer
+Algorithm == INSTANCE GenericMulticast2 WITH
+    INITIAL_MESSAGES <- [g \in Groups |-> MessagesToTupleSet(MessagesCombinations[(g % NMESSAGES) + 1])]
+
+vars == <<
+    K,
+    PreviousMsgs,
+    Delivered,
+    Votes,
+    MemoryBuffer,
+    QuasiReliableChannel,
+    GenericBroadcastBuffer
+>>
+
+----------------------------------------------------------
+
+Spec == Algorithm!Spec
+
+----------------------------------------------------------
+(*
+If a correct process p, delivers both m1 and m2, where p in
+m1.d and m2.d, then p delivers m1 before m2 or delivers m2
+before m1.
+*)
+Collision ==
+    []\A g \in Groups:
+        \A p \in ProcessesInGroup[g]:
+            \A m1, m2 \in AllMessages: m1.id /= m2.id
+                /\ Algorithm!WasDelivered(g, p, m1)
+                /\ Algorithm!WasDelivered(g, p, m2)
+                /\ CONFLICTR(m1, m2) => Algorithm!DeliveredInstant(g, p, m1) /= Algorithm!DeliveredInstant(g, p, m2)
+==========================================================

--- a/GenericMulticast2/GenericMulticast2.tla
+++ b/GenericMulticast2/GenericMulticast2.tla
@@ -1,0 +1,256 @@
+-------------------- MODULE GenericMulticast2 --------------------
+
+LOCAL INSTANCE Commons
+LOCAL INSTANCE Naturals
+LOCAL INSTANCE FiniteSets
+
+CONSTANT NPROCESSES
+CONSTANT NGROUPS
+CONSTANT INITIAL_MESSAGES
+CONSTANT CONFLICTR(_,_)
+
+-----------------------------------------------------------------
+
+LOCAL Processes == {p : p \in 1 .. NPROCESSES}
+LOCAL Groups == {g : g \in 1 .. NGROUPS}
+
+-----------------------------------------------------------------
+\* The module containing the Atomic Broadcast primitive.
+VARIABLE GenericBroadcastBuffer
+GenericBroadcast == INSTANCE GenericBroadcast
+
+\* The module containing the quasi reliable channel.
+VARIABLE QuasiReliableChannel
+QuasiReliable == INSTANCE QuasiReliable WITH
+    INITIAL_MESSAGES <- {}
+
+\* The algorithm's `Mem` structure. We use a separate module.
+VARIABLE MemoryBuffer
+Memory == INSTANCE Memory
+
+-----------------------------------------------------------------
+
+VARIABLES
+    \* The process local clock.
+    K,
+
+    \* The set contains previous messages.
+    \* We use this with the CONFLICTR to verify conflicting messages.
+    PreviousMsgs,
+
+    \* The set of delivered messages.
+    \* This set is not an algorithm requirement. We use this to help check the
+    \* algorithm's properties.
+    Delivered,
+
+    \* A set contains the processes' votes for the message's timestamp.
+    \* This structure is implicit in the algorithm.
+    Votes
+
+vars == <<K, MemoryBuffer, PreviousMsgs, Delivered, Votes,
+          GenericBroadcastBuffer, QuasiReliableChannel>>
+-----------------------------------------------------------------
+
+\* These are the handlers. The actual algorithm resides here, the lambdas
+\* only assert the guarding predicates before calling the handler.
+
+LOCAL ComputeGroupSeqNumberHandler(g, p, msg, state, ts) ==
+    /\ \/ /\ state = 0
+          /\ \/ /\ \E prev \in PreviousMsgs[g][p]: CONFLICTR(msg, prev)
+                /\ K' = [K EXCEPT ![g][p] = K[g][p] + 1]
+                /\ PreviousMsgs' = [PreviousMsgs EXCEPT ![g][p] = {msg}]
+             \/ /\ \A prev \in PreviousMsgs[g][p]: ~CONFLICTR(msg, prev)
+                /\ PreviousMsgs' = [PreviousMsgs EXCEPT ![g][p] = PreviousMsgs[g][p] \cup {msg}]
+                /\ UNCHANGED K
+       \/ /\ state = 2
+    /\ \/ /\ Cardinality(msg.d) > 1
+          /\ \/ /\ state = 0
+                /\ Memory!Insert(g, p, <<msg, state, K'[g][p]>>)
+                /\ QuasiReliable!Send(<<msg, g, K'[g][p]>>)
+             \/ /\ state = 2
+                /\ \/ /\ ts > K[g][p]
+                      /\ K' = [K EXCEPT ![g][p] = ts]
+                      /\ PreviousMsgs' = [PreviousMsgs EXCEPT ![g][p] = {}]
+                   \/ /\ ts <= K[g][p]
+                      /\ UNCHANGED <<K, PreviousMsgs>>
+                /\ Memory!Insert(g, p, <<msg, 3, ts>>)
+                /\ UNCHANGED <<QuasiReliableChannel>>
+       \/ /\ Cardinality(msg.d) = 1
+          /\ Memory!Insert(g, p, <<msg, 3, K'[g][p]>>)
+          /\ UNCHANGED QuasiReliableChannel
+    /\ UNCHANGED <<Delivered, Votes>>
+
+LOCAL GatherGroupsTimestampHandler(g, p, msg, ts, tsf) ==
+    /\ \/ /\ ts >= tsf \/ \A prev \in PreviousMsgs[g][p]: ~CONFLICTR(msg, prev)
+          /\ Memory!Insert(g, p, <<msg, 3, ts>>)
+          /\ UNCHANGED <<K, PreviousMsgs, GenericBroadcastBuffer, Delivered>>
+       \/ /\ ts < tsf
+          /\ Memory!Insert(g, p, <<msg, 2, tsf>>)
+          /\ GenericBroadcast!GBroadcast(g, <<msg, 2, tsf>>)
+          /\ UNCHANGED <<K, PreviousMsgs, Delivered>>
+
+LOCAL DoDeliverHandler(g, p, m_1, ts_1) ==
+    /\ LET
+        G == Memory!ForAllFilter(g, p, LAMBDA t_i, t_j: t_i[2] = 3 /\ ~CONFLICTR(t_i[1], t_j[1]))
+        D == G \cup {<<m_1, 3, ts_1>>}
+        F == {t[1]: t \in D}
+       IN
+        /\ Memory!Remove(g, p, D)
+        /\ Delivered' = [Delivered EXCEPT ![g][p] = Delivered[g][p] \cup AppendEnumerating(Cardinality(Delivered[g][p]), F)]
+        /\ UNCHANGED <<QuasiReliableChannel, GenericBroadcastBuffer, Votes, PreviousMsgs, K>>
+
+-----------------------------------------------------------------
+
+(***************************************************************************)
+(*                                                                         *)
+(* Executes when process P receives a message M from the Atomic Broadcast  *)
+(* primitive and M is in P's memory. This procedure is extensive, with     *)
+(* multiple branches based on the message's state and destination. Let's   *)
+(* split the explanation.                                                  *)
+(*                                                                         *)
+(* When M's state is S0, we first verify if M conflicts with messages in   *)
+(* the PreviousMsgs set. If a conflict exists, we increase P's local clock *)
+(* by one and clear the PreviousMsgs set.                                  *)
+(*                                                                         *)
+(* When message M has a single group as the destination, it is already in  *)
+(* its destination and is synchronized because we received M from Atomic   *)
+(* Broadcast primitive. P stores M in memory with state S3 and timestamp   *)
+(* with the current clock value.                                           *)
+(*                                                                         *)
+(* When M includes multiple groups in the destination, the participants    *)
+(* must agree on the final timestamp. When M's state is S0, P will send    *)
+(* its timestamp proposition to all other participants, which is the       *)
+(* current clock value, and update M's state to S1 and timestamp. If M's   *)
+(* state is S2, we are synchronizing the local group, meaning we may need  *)
+(* to leap the clock to the M's received timestamp and then set M to state *)
+(* S3.                                                                     *)
+(*                                                                         *)
+(***************************************************************************)
+ComputeGroupSeqNumber(g, p) ==
+    /\ GenericBroadcast!GBDeliver(g, p,
+        LAMBDA t:
+            /\ ComputeGroupSeqNumberHandler(g, p, t[1], t[2], t[3]))
+
+(***************************************************************************)
+(*                                                                         *)
+(* After exchanging the votes between groups, processes must select the    *)
+(* final timestamp. When we have one proposal from each group in message   *)
+(* M's destination, the highest vote is the decided timestamp. If P's      *)
+(* local clock is smaller than the value, we broadcast the message to the  *)
+(* local group with state S2 and save it in memory. Otherwise, we update   *)
+(* the in-memory to state S3.                                              *)
+(*                                                                         *)
+(* We only execute the procedure once we have proposals from all           *)
+(* participating groups. Since we receive messages from the quasi-reliable *)
+(* channel, we keep the votes in the Votes structure. This structure is    *)
+(* implicit in the algorithm.                                              *)
+(*                                                                         *)
+(***************************************************************************)
+GatherGroupsTimestamp(g, p) ==
+    /\ QuasiReliable!ReceiveAndConsume(g, p,
+        LAMBDA t:
+            /\ LET
+                msg == t[1]
+                origin == t[2]
+                vote == <<msg.id, origin, t[3]>>
+                election == {v \in (Votes[g][p] \cup {vote}): v[1] = msg.id}
+                elected == Max({x[3] : x \in election})
+               IN
+                \* We only execute the procedure when we have proposals from all groups.
+                /\ \/ /\ Cardinality(election) = Cardinality(msg.d) /\ Memory!Contains(g, p, LAMBDA memory: msg.id = memory[1].id)
+                      /\ GatherGroupsTimestampHandler(g, p, msg, t[3], elected)
+                      /\ Votes' = [Votes EXCEPT ![g][p] = {x \in Votes[g][p]: x[1] /= msg.id}]
+                   \/ /\ Cardinality(election) < Cardinality(msg.d)
+                      /\ Votes' = [Votes EXCEPT ![g][p] = Votes[g][p] \cup {vote}]
+                      /\ UNCHANGED <<MemoryBuffer, K, PreviousMsgs, GenericBroadcastBuffer>>
+                /\ UNCHANGED <<Delivered>>)
+
+(***************************************************************************)
+(*                                                                         *)
+(* When messages are to deliver, we select them and call the delivery      *)
+(* primitive. Ready means they are in state S3, and the message either     *)
+(* does not conflict with any other in the memory structure or is smaller  *)
+(* than all others. Once a message is ready, we also collect the messages  *)
+(* that do not conflict with any other for delivery in a single batch.     *)
+(*                                                                         *)
+(***************************************************************************)
+DoDeliver(g, p) ==
+    \* We are accessing the buffer directly, and not through the `Memory` instance.
+    \* We do this because is easier and because we are only reading the values here.
+    \* Any changes we do through the instance.
+    \E <<m_1, state, ts_1>> \in MemoryBuffer[g][p]:
+        /\ state = 3
+        /\ \A <<m_2, ignore, ts_2>> \in (MemoryBuffer[g][p] \ {<<m_1, state, ts_1>>}):
+            /\ \/ ~CONFLICTR(m_1, m_2)
+               \/ ts_1 < ts_2 \/ (m_1.id < m_2.id /\ ts_1 = ts_2)
+        /\ LET
+            G == Memory!ForAllFilter(g, p, LAMBDA t_i, t_j: t_i[2] = 3 /\ ~CONFLICTR(t_i[1], t_j[1]))
+            D == G \cup {<<m_1, 3, ts_1>>}
+            F == {t[1]: t \in D}
+           IN
+            /\ Memory!Remove(g, p, D)
+            /\ Delivered' = [Delivered EXCEPT ![g][p] = Delivered[g][p] \cup AppendEnumerating(Cardinality(Delivered[g][p]), F)]
+            /\ UNCHANGED <<QuasiReliableChannel, GenericBroadcastBuffer, Votes, PreviousMsgs, K>>
+-----------------------------------------------------------------
+
+LOCAL InitProtocol ==
+    /\ K = [i \in Groups |-> [p \in Processes |-> 0]]
+    /\ Memory!Init
+    /\ PreviousMsgs = [i \in Groups |-> [p \in Processes |-> {}]]
+    /\ Delivered = [i \in Groups |-> [p \in Processes |-> {}]]
+    /\ Votes = [i \in Groups |-> [p \in Processes |-> {}]]
+
+LOCAL InitCommunication ==
+    /\ GenericBroadcast!Init
+    /\ QuasiReliable!Init
+
+Init == InitProtocol /\ InitCommunication
+
+-----------------------------------------------------------------
+Step(g, p) ==
+    \/ ComputeGroupSeqNumber(g, p)
+    \/ GatherGroupsTimestamp(g, p)
+    \/ DoDeliver(g, p)
+
+GroupStep(g) ==
+    \E p \in Processes: Step(g, p)
+
+Next ==
+    \/ \E g \in Groups: GroupStep(g)
+    \/ UNCHANGED vars
+
+Spec == Init /\ [][Next]_vars
+
+SpecFair == Spec /\ WF_vars(\E g \in Groups: GroupStep(g))
+
+-----------------------------------------------------------------
+
+ASSUME
+    /\ NGROUPS \in (Nat \ {0})
+    /\ NPROCESSES \in (Nat \ {0})
+    /\ IsFiniteSet(INITIAL_MESSAGES)
+
+-----------------------------------------------------------------
+
+\* Helper functions to aid when checking the algorithm properties.
+
+WasDelivered(g, p, m) ==
+    (*************************************************************************)
+    (* Verifies if the given process `p` in group `g` delivered message `m`. *)
+    (*************************************************************************)
+    /\ \E <<idx, n>> \in Delivered[g][p]: n.id = m.id
+
+FilterDeliveredMessages(g, p, m) ==
+    (***********************************************************************)
+    (* Retrieve the set of messages with the same id as message `m`        *)
+    (* delivered by the given process `p` in group `g`.                    *)
+    (***********************************************************************)
+    {<<idx, n>> \in Delivered[g][p]: n.id = m.id}
+
+DeliveredInstant(g, p, m) ==
+    (***********************************************************************)
+    (* Retrieve the instant the given process `p` in group `g` delivered   *)
+    (* message `m`.                                                        *)
+    (***********************************************************************)
+    (CHOOSE <<t, n>> \in Delivered[g][p]: n.id = m.id)[1]
+=================================================================

--- a/GenericMulticast2/Integrity/Integrity-AlwaysConflict.cfg
+++ b/GenericMulticast2/Integrity/Integrity-AlwaysConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 2
+    NMESSAGES = 1
+    NGROUPS = 1
+    CONFLICTR <- AlwaysConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Integrity

--- a/GenericMulticast2/Integrity/Integrity-IdConflict.cfg
+++ b/GenericMulticast2/Integrity/Integrity-IdConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 2
+    NMESSAGES = 1
+    NGROUPS = 2
+    CONFLICTR <- IdConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Integrity

--- a/GenericMulticast2/Integrity/Integrity-NeverConflict.cfg
+++ b/GenericMulticast2/Integrity/Integrity-NeverConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 2
+    NMESSAGES = 2
+    NGROUPS = 1
+    CONFLICTR <- NeverConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Integrity

--- a/GenericMulticast2/Integrity/Integrity.tla
+++ b/GenericMulticast2/Integrity/Integrity.tla
@@ -1,5 +1,5 @@
 -------------------- MODULE Integrity --------------------
-EXTENDS Naturals, FiniteSets, Commons, Sequences
+EXTENDS Naturals, FiniteSets, Sequences, Commons
 
 CONSTANT NPROCESSES
 CONSTANT NGROUPS
@@ -27,9 +27,9 @@ VARIABLES
     Votes,
     MemoryBuffer,
     QuasiReliableChannel,
-    AtomicBroadcastBuffer
-Algorithm == INSTANCE GenericMulticast1 WITH
-    INITIAL_MESSAGES <- [g \in Groups |-> MessagesToTuple(CombinationsToSend[(g % NMESSAGES) + 1])]
+    GenericBroadcastBuffer
+Algorithm == INSTANCE GenericMulticast2 WITH
+    INITIAL_MESSAGES <- [g \in Groups |-> MessagesToTupleSet(CombinationsToSend[(g % NMESSAGES) + 1])]
 
 vars == <<
     K,
@@ -38,7 +38,7 @@ vars == <<
     Votes,
     MemoryBuffer,
     QuasiReliableChannel,
-    AtomicBroadcastBuffer
+    GenericBroadcastBuffer
 >>
 
 ----------------------------------------------------------

--- a/GenericMulticast2/Makefile
+++ b/GenericMulticast2/Makefile
@@ -1,0 +1,16 @@
+SPEC_FOLDER=$(ROOT_FOLDER)/GenericMulticast2
+
+agreement:
+	$$0 $(ROOT_FOLDER)/bin/tlc.sh $(SPEC_FOLDER) Agreement
+
+collision:
+	$$0 $(ROOT_FOLDER)/bin/tlc.sh $(SPEC_FOLDER) Collision
+
+integrity:
+	$$0 $(ROOT_FOLDER)/bin/tlc.sh $(SPEC_FOLDER) Integrity
+
+partial-order:
+	$$0 $(ROOT_FOLDER)/bin/tlc.sh $(SPEC_FOLDER) PartialOrder
+
+validity:
+	$$0 $(ROOT_FOLDER)/bin/tlc.sh $(SPEC_FOLDER) Validity

--- a/GenericMulticast2/PartialOrder/PartialOrder-AlwaysConflict.cfg
+++ b/GenericMulticast2/PartialOrder/PartialOrder-AlwaysConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 4
+    NGROUPS = 2
+    CONFLICTR <- AlwaysConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    PartialOrder

--- a/GenericMulticast2/PartialOrder/PartialOrder-IdConflict.cfg
+++ b/GenericMulticast2/PartialOrder/PartialOrder-IdConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 4
+    NGROUPS = 2
+    CONFLICTR <- IdConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    PartialOrder

--- a/GenericMulticast2/PartialOrder/PartialOrder-NeverConflict.cfg
+++ b/GenericMulticast2/PartialOrder/PartialOrder-NeverConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 4
+    NGROUPS = 2
+    CONFLICTR <- NeverConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    PartialOrder

--- a/GenericMulticast2/PartialOrder/PartialOrder.tla
+++ b/GenericMulticast2/PartialOrder/PartialOrder.tla
@@ -1,0 +1,71 @@
+----------------- MODULE PartialOrder --------------------
+EXTENDS Naturals, FiniteSets, Commons
+
+CONSTANT NGROUPS
+CONSTANT NPROCESSES
+CONSTANT NMESSAGES
+CONSTANT CONFLICTR(_, _)
+
+----------------------------------------------------------
+
+LOCAL Processes == 1 .. NPROCESSES
+LOCAL Groups == 1 .. NGROUPS
+LOCAL ProcessesInGroup == [g \in Groups |-> Processes]
+
+LOCAL AllMessages == CreateMessages(NMESSAGES, Groups, Processes)
+LOCAL MessagesCombinations == CreatePossibleMessages(AllMessages)
+
+----------------------------------------------------------
+
+VARIABLES
+    K,
+    PreviousMsgs,
+    Delivered,
+    Votes,
+    MemoryBuffer,
+    QuasiReliableChannel,
+    GenericBroadcastBuffer
+Algorithm == INSTANCE GenericMulticast2 WITH
+    INITIAL_MESSAGES <- [g \in Groups |-> MessagesToTupleSet(MessagesCombinations[(g % NMESSAGES) + 1])]
+
+vars == <<
+    K,
+    PreviousMsgs,
+    Delivered,
+    Votes,
+    MemoryBuffer,
+    QuasiReliableChannel,
+    GenericBroadcastBuffer
+>>
+
+----------------------------------------------------------
+
+Spec == Algorithm!Spec
+
+----------------------------------------------------------
+LOCAL BothDelivered(g, p1, p2, m1, m2) ==
+    /\ Algorithm!WasDelivered(g, p1, m1) /\ Algorithm!WasDelivered(g, p1, m2)
+    /\ Algorithm!WasDelivered(g, p2, m1) /\ Algorithm!WasDelivered(g, p2, m2)
+LOCAL LHS(g, p1, p2, m1, m2) ==
+    /\ {p1, p2} \subseteq (m1.d \intersect m2.d)
+    /\ CONFLICTR(m1, m2)
+    /\ BothDelivered(g, p1, p2, m1, m2)
+LOCAL RHS(g, p1, p2, m1, m2) ==
+    /\ LET
+        pm == Algorithm!DeliveredInstant(g, p1, m1)
+        pn == Algorithm!DeliveredInstant(g, p1, m2)
+        qm == Algorithm!DeliveredInstant(g, p2, m1)
+        qn == Algorithm!DeliveredInstant(g, p2, m2)
+        IN
+         /\ (pm < pn) <=> (qm < qn)
+(*
+If a correct processes p1, p2 both deliver messages m1 and m2,
+m1 conflict with m2, and p1 and p2 are both in m1.d and m2.d,
+then p1 delivers m1 before m2, if, and only if, p2 deliver m1 before m2.
+*)
+PartialOrder ==
+    []\A g \in Groups:
+        \A p1, p2 \in ProcessesInGroup[g]:
+            \A m1, m2 \in AllMessages:
+                LHS(g, p1, p2, m1, m2) => RHS(g, p1, p2, m1, m2)
+==========================================================

--- a/GenericMulticast2/Validity/Validity-AlwaysConflict.cfg
+++ b/GenericMulticast2/Validity/Validity-AlwaysConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 2
+    NGROUPS = 2
+    CONFLICTR <- AlwaysConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Validity

--- a/GenericMulticast2/Validity/Validity-IdConflict.cfg
+++ b/GenericMulticast2/Validity/Validity-IdConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 2
+    NGROUPS = 2
+    CONFLICTR <- IdConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Validity

--- a/GenericMulticast2/Validity/Validity-NeverConflict.cfg
+++ b/GenericMulticast2/Validity/Validity-NeverConflict.cfg
@@ -1,0 +1,11 @@
+CONSTANTS
+    NPROCESSES = 1
+    NMESSAGES = 2
+    NGROUPS = 2
+    CONFLICTR <- NeverConflict
+
+SPECIFICATION
+    Spec
+
+PROPERTIES
+    Validity

--- a/GenericMulticast2/Validity/Validity.tla
+++ b/GenericMulticast2/Validity/Validity.tla
@@ -1,0 +1,60 @@
+---- MODULE Validity ----
+EXTENDS Naturals, FiniteSets, Commons
+
+CONSTANT NPROCESSES
+CONSTANT NGROUPS
+CONSTANT NMESSAGES
+CONSTANT CONFLICTR(_, _)
+
+----------------------------------------------------------
+
+LOCAL Processes == 1 .. NPROCESSES
+LOCAL Groups == 1 .. NGROUPS
+LOCAL ProcessesInGroup == [g \in Groups |-> Processes]
+
+LOCAL AllMessages == CreateMessages(NMESSAGES, Groups, Processes)
+LOCAL MessagesCombinations == CreatePossibleMessages(AllMessages)
+----------------------------------------------------------
+
+VARIABLES
+    K,
+    PreviousMsgs,
+    Delivered,
+    Votes,
+    MemoryBuffer,
+    QuasiReliableChannel,
+    GenericBroadcastBuffer
+Algorithm == INSTANCE GenericMulticast2 WITH
+    INITIAL_MESSAGES <- [g \in Groups |-> MessagesToTupleSet(MessagesCombinations[(g % NMESSAGES) + 1])]
+
+vars == <<
+    K,
+    PreviousMsgs,
+    Delivered,
+    Votes,
+    MemoryBuffer,
+    QuasiReliableChannel,
+    GenericBroadcastBuffer
+>>
+----------------------------------------------------------
+
+Spec == Algorithm!SpecFair
+
+----------------------------------------------------------
+(***************************************************************************)
+(*                                                                         *)
+(*     If a correct process GM-Cast a message `m` to `m.d`, then some      *)
+(* process in `m.d` eventually GM-Deliver `m`.                             *)
+(*                                                                         *)
+(*     We verify that all messages on the messages that will be send, then *)
+(* we verify that exists a process on the existent processes that did sent *)
+(* the message and eventually exists a process on `m.d` that delivers the  *)
+(* message.                                                                *)
+(*                                                                         *)
+(***************************************************************************)
+Validity ==
+    \A m \in AllMessages:
+        m.o[1] \in Groups /\ m.o[2] \in Processes
+            ~> \E g \in m.d:
+                \E p \in ProcessesInGroup[g]: Algorithm!WasDelivered(g, p, m)
+==========================================================

--- a/GenericMulticast2/dependencies.txt
+++ b/GenericMulticast2/dependencies.txt
@@ -1,0 +1,5 @@
+Commons
+GenericBroadcast
+GenericMulticast2
+Memory
+QuasiReliable

--- a/Makefile
+++ b/Makefile
@@ -32,5 +32,20 @@ m1-partial-order:
 m1-validity:
 	@$(MAKE) -C GenericMulticast1 validity
 
+m2-agreement:
+	@$(MAKE) -C GenericMulticast2 agreement
+
+m2-collision:
+	@$(MAKE) -C GenericMulticast2 collision
+
+m2-integrity:
+	@$(MAKE) -C GenericMulticast2 integrity
+
+m2-partial-order:
+	@$(MAKE) -C GenericMulticast2 partial-order
+
+m2-validity:
+	@$(MAKE) -C GenericMulticast2 validity
+
 prune:
 	$$0 $(ROOT_FOLDER)/bin/prune.sh


### PR DESCRIPTION
* We created the Generic Broadcast abstraction. We use sequences and
  sets to create the abstraction.

* We copied over the Generic Multicast 1 specification and replaced the
  Atomic Broadcast with the Generic Broadcast abstraction.

* Copied all the properties are fixed the integrity verification in both
  the Generic Multicast 1 and 2.